### PR TITLE
Deduplicate parent counts when batch-logging events

### DIFF
--- a/my/core/log-via-tasker.lua
+++ b/my/core/log-via-tasker.lua
@@ -51,8 +51,8 @@ function M.log_events_to_spreadsheet(events, ui_callback)
     local message = "✓ Logged:"
     for k, event in pairs(data) do
         message = message .. "\n" .. table.concat(event, " - ")
-        M.store_log(event[1], event[2], event[3])
     end
+    M.store_logs(data)
 
     ui_callback(message)
 end
@@ -116,6 +116,56 @@ function M.store_log(event, value, detail)
 
         logs[event].values[value].details[detail].count = (logs[event].values[value].details[detail].count or 0) + 1
         logs[event].values[value].details[detail].last_logged = time_utils.get_current_timestamp()
+    end
+
+    prefs.logs = logs
+end
+
+function M.store_logs(events)
+    local logs = prefs.logs or {}
+    local seen_events = {}
+    local seen_values = {}
+    local timestamp = time_utils.get_current_timestamp()
+
+    for _, event_data in ipairs(events) do
+        local event, value, detail = event_data[1], event_data[2], event_data[3]
+
+        if not logs[event] then
+            logs[event] = { count = 0, values = {} }
+        end
+
+        if not seen_events[event] then
+            logs[event].count = (logs[event].count or 0) + 1
+            seen_events[event] = true
+        end
+        logs[event].last_logged = timestamp
+        logs[event].last_value = value
+
+        if not logs[event].values[value] then
+            logs[event].values[value] = { count = 0, details = {} }
+        end
+
+        local value_key = event .. "\0" .. value
+        if not seen_values[value_key] then
+            logs[event].values[value].count = (logs[event].values[value].count or 0) + 1
+            seen_values[value_key] = true
+        end
+        logs[event].values[value].last_logged = timestamp
+
+        if detail ~= "" and detail ~= nil then
+            logs[event].values[value].last_detail = detail
+
+            if not logs[event].values[value].details then
+                logs[event].values[value].details = {}
+            end
+
+            if not logs[event].values[value].details[detail] then
+                logs[event].values[value].details[detail] = { count = 0 }
+            end
+
+            logs[event].values[value].details[detail].count = (logs[event].values[value].details[detail].count or 0) + 1
+            logs[event].values[value].details[detail].last_logged = timestamp
+        end
     end
 
     prefs.logs = logs

--- a/my/core/log-via-tasker.lua
+++ b/my/core/log-via-tasker.lua
@@ -85,42 +85,6 @@ function M.store_ignore(event, value, detail)
     prefs.logs = logs
 end
 
-function M.store_log(event, value, detail)
-    local logs = prefs.logs or {}
-
-    if not logs[event] then
-        logs[event] = { count = 0, values = {} }
-    end
-
-    logs[event].count = (logs[event].count or 0) + 1
-    logs[event].last_logged = time_utils.get_current_timestamp()
-    logs[event].last_value = value
-
-    if not logs[event].values[value] then
-        logs[event].values[value] = { count = 0, details = {} }
-    end
-
-    logs[event].values[value].count = (logs[event].values[value].count or 0) + 1
-    logs[event].values[value].last_logged = time_utils.get_current_timestamp()
-
-    if detail ~= "" and detail ~= nil then
-        logs[event].values[value].last_detail = detail
-
-        if not logs[event].values[value].details then
-            logs[event].values[value].details = {}
-        end
-
-        if not logs[event].values[value].details[detail] then
-            logs[event].values[value].details[detail] = { count = 0 }
-        end
-
-        logs[event].values[value].details[detail].count = (logs[event].values[value].details[detail].count or 0) + 1
-        logs[event].values[value].details[detail].last_logged = time_utils.get_current_timestamp()
-    end
-
-    prefs.logs = logs
-end
-
 function M.store_logs(events)
     local logs = prefs.logs or {}
     local seen_events = {}

--- a/my/long-covid.lua
+++ b/my/long-covid.lua
@@ -94,7 +94,7 @@ local capacity_buttons = {
 }
 
 function reset_capacity()
-    logger.store_log("Capacity", "reset")
+    logger.store_logs({{"Capacity", "reset"}})
     render_widget()
 end
 
@@ -167,7 +167,7 @@ function handle_main_dialog_result(results, dialogs, loggables, name, override_l
     if result.meta.children and #result.meta.children > 0 then
         local childlogs = util.map(result.meta.children, get_loggable)
         if override_logs then return override_logs(childlogs) end
-        logger.store_log(name, result.value, result.meta.detail)
+        logger.store_logs({{name, result.value, result.meta.detail}})
         return execute_logs(name, loggables, childlogs)
     end
 

--- a/tests/test_store_logs.lua
+++ b/tests/test_store_logs.lua
@@ -45,22 +45,22 @@ local function reset_prefs()
     mock_prefs.logs = nil
 end
 
--- Tests for store_log (single event, existing behavior)
+-- Tests for store_logs
 
-test.add_test("store_log: single event increments all levels", function()
+test.add_test("store_logs: single event increments all levels", function()
     reset_prefs()
-    logger.store_log("Intervention", "physio", "one")
+    logger.store_logs({{"Intervention", "physio", "one"}})
 
     test.assert_equals(mock_prefs.logs["Intervention"].count, 1, "event count")
     test.assert_equals(mock_prefs.logs["Intervention"].values["physio"].count, 1, "value count")
     test.assert_equals(mock_prefs.logs["Intervention"].values["physio"].details["one"].count, 1, "detail count")
 end)
 
-test.add_test("store_log: repeated calls increment all levels each time", function()
+test.add_test("store_logs: repeated single-item calls increment parent each time", function()
     reset_prefs()
-    logger.store_log("Intervention", "physio", "one")
-    logger.store_log("Intervention", "physio", "two")
-    logger.store_log("Intervention", "physio", "three")
+    logger.store_logs({{"Intervention", "physio", "one"}})
+    logger.store_logs({{"Intervention", "physio", "two"}})
+    logger.store_logs({{"Intervention", "physio", "three"}})
 
     test.assert_equals(mock_prefs.logs["Intervention"].count, 3, "event count should be 3")
     test.assert_equals(mock_prefs.logs["Intervention"].values["physio"].count, 3, "value count should be 3")
@@ -68,8 +68,6 @@ test.add_test("store_log: repeated calls increment all levels each time", functi
     test.assert_equals(mock_prefs.logs["Intervention"].values["physio"].details["two"].count, 1, "detail two count")
     test.assert_equals(mock_prefs.logs["Intervention"].values["physio"].details["three"].count, 1, "detail three count")
 end)
-
--- Tests for store_logs (batch, deduplicated behavior)
 
 test.add_test("store_logs: same event+value with different details increments parent only once", function()
     reset_prefs()
@@ -86,7 +84,7 @@ test.add_test("store_logs: same event+value with different details increments pa
     test.assert_equals(mock_prefs.logs["Intervention"].values["physio"].details["three"].count, 1, "detail three count")
 end)
 
-test.add_test("store_logs: single event behaves same as store_log", function()
+test.add_test("store_logs: single event in batch", function()
     reset_prefs()
     logger.store_logs({
         { "Intervention", "physio", "one" },

--- a/tests/test_store_logs.lua
+++ b/tests/test_store_logs.lua
@@ -1,0 +1,174 @@
+package.path = "../?.lua;" .. package.path
+
+-- Mock dependencies before requiring log-via-tasker
+local mock_prefs = {}
+package.loaded["prefs"] = mock_prefs
+package.loaded["core.time-utils"] = {
+    get_current_timestamp = function() return os.time() end
+}
+package.loaded["core.util"] = require("my.core.util")
+
+local logger = require("my.core.log-via-tasker")
+
+-- Test framework
+local test = {}
+test.tests = {}
+test.passed = 0
+test.failed = 0
+
+function test.assert_equals(actual, expected, message)
+    if actual ~= expected then
+        error("ASSERT_EQUALS FAILED: " .. (message or "") .. "\nExpected: " .. tostring(expected) .. "\nActual: " .. tostring(actual))
+    end
+end
+
+function test.add_test(name, test_func)
+    table.insert(test.tests, {name = name, func = test_func})
+end
+
+function test.run_tests()
+    for _, t in ipairs(test.tests) do
+        local success, err = pcall(t.func)
+        if success then
+            print("✓ " .. t.name)
+            test.passed = test.passed + 1
+        else
+            print("✗ " .. t.name .. ": " .. err)
+            test.failed = test.failed + 1
+        end
+    end
+    print("\nResults: " .. test.passed .. " passed, " .. test.failed .. " failed")
+    return test.failed == 0
+end
+
+local function reset_prefs()
+    mock_prefs.logs = nil
+end
+
+-- Tests for store_log (single event, existing behavior)
+
+test.add_test("store_log: single event increments all levels", function()
+    reset_prefs()
+    logger.store_log("Intervention", "physio", "one")
+
+    test.assert_equals(mock_prefs.logs["Intervention"].count, 1, "event count")
+    test.assert_equals(mock_prefs.logs["Intervention"].values["physio"].count, 1, "value count")
+    test.assert_equals(mock_prefs.logs["Intervention"].values["physio"].details["one"].count, 1, "detail count")
+end)
+
+test.add_test("store_log: repeated calls increment all levels each time", function()
+    reset_prefs()
+    logger.store_log("Intervention", "physio", "one")
+    logger.store_log("Intervention", "physio", "two")
+    logger.store_log("Intervention", "physio", "three")
+
+    test.assert_equals(mock_prefs.logs["Intervention"].count, 3, "event count should be 3")
+    test.assert_equals(mock_prefs.logs["Intervention"].values["physio"].count, 3, "value count should be 3")
+    test.assert_equals(mock_prefs.logs["Intervention"].values["physio"].details["one"].count, 1, "detail one count")
+    test.assert_equals(mock_prefs.logs["Intervention"].values["physio"].details["two"].count, 1, "detail two count")
+    test.assert_equals(mock_prefs.logs["Intervention"].values["physio"].details["three"].count, 1, "detail three count")
+end)
+
+-- Tests for store_logs (batch, deduplicated behavior)
+
+test.add_test("store_logs: same event+value with different details increments parent only once", function()
+    reset_prefs()
+    logger.store_logs({
+        { "Intervention", "physio", "one" },
+        { "Intervention", "physio", "two" },
+        { "Intervention", "physio", "three" },
+    })
+
+    test.assert_equals(mock_prefs.logs["Intervention"].count, 1, "event count should be 1")
+    test.assert_equals(mock_prefs.logs["Intervention"].values["physio"].count, 1, "value count should be 1")
+    test.assert_equals(mock_prefs.logs["Intervention"].values["physio"].details["one"].count, 1, "detail one count")
+    test.assert_equals(mock_prefs.logs["Intervention"].values["physio"].details["two"].count, 1, "detail two count")
+    test.assert_equals(mock_prefs.logs["Intervention"].values["physio"].details["three"].count, 1, "detail three count")
+end)
+
+test.add_test("store_logs: single event behaves same as store_log", function()
+    reset_prefs()
+    logger.store_logs({
+        { "Intervention", "physio", "one" },
+    })
+
+    test.assert_equals(mock_prefs.logs["Intervention"].count, 1, "event count")
+    test.assert_equals(mock_prefs.logs["Intervention"].values["physio"].count, 1, "value count")
+    test.assert_equals(mock_prefs.logs["Intervention"].values["physio"].details["one"].count, 1, "detail count")
+end)
+
+test.add_test("store_logs: different events get separate counts", function()
+    reset_prefs()
+    logger.store_logs({
+        { "Intervention", "physio", "one" },
+        { "Activity", "walking", "short" },
+    })
+
+    test.assert_equals(mock_prefs.logs["Intervention"].count, 1, "intervention event count")
+    test.assert_equals(mock_prefs.logs["Intervention"].values["physio"].count, 1, "physio value count")
+    test.assert_equals(mock_prefs.logs["Activity"].count, 1, "activity event count")
+    test.assert_equals(mock_prefs.logs["Activity"].values["walking"].count, 1, "walking value count")
+end)
+
+test.add_test("store_logs: different values under same event get separate value counts", function()
+    reset_prefs()
+    logger.store_logs({
+        { "Intervention", "physio", "one" },
+        { "Intervention", "massage", "deep" },
+    })
+
+    test.assert_equals(mock_prefs.logs["Intervention"].count, 1, "event count should be 1")
+    test.assert_equals(mock_prefs.logs["Intervention"].values["physio"].count, 1, "physio value count")
+    test.assert_equals(mock_prefs.logs["Intervention"].values["massage"].count, 1, "massage value count")
+end)
+
+test.add_test("store_logs: events without detail only increment event and value", function()
+    reset_prefs()
+    logger.store_logs({
+        { "Intervention", "physio" },
+        { "Intervention", "massage" },
+    })
+
+    test.assert_equals(mock_prefs.logs["Intervention"].count, 1, "event count should be 1")
+    test.assert_equals(mock_prefs.logs["Intervention"].values["physio"].count, 1, "physio value count")
+    test.assert_equals(mock_prefs.logs["Intervention"].values["massage"].count, 1, "massage value count")
+end)
+
+test.add_test("store_logs: accumulates with existing counts", function()
+    reset_prefs()
+    -- First batch
+    logger.store_logs({
+        { "Intervention", "physio", "one" },
+        { "Intervention", "physio", "two" },
+    })
+    -- Second batch
+    logger.store_logs({
+        { "Intervention", "physio", "three" },
+        { "Intervention", "physio", "four" },
+    })
+
+    test.assert_equals(mock_prefs.logs["Intervention"].count, 2, "event count should be 2 (one per batch)")
+    test.assert_equals(mock_prefs.logs["Intervention"].values["physio"].count, 2, "value count should be 2 (one per batch)")
+    test.assert_equals(mock_prefs.logs["Intervention"].values["physio"].details["one"].count, 1)
+    test.assert_equals(mock_prefs.logs["Intervention"].values["physio"].details["two"].count, 1)
+    test.assert_equals(mock_prefs.logs["Intervention"].values["physio"].details["three"].count, 1)
+    test.assert_equals(mock_prefs.logs["Intervention"].values["physio"].details["four"].count, 1)
+end)
+
+test.add_test("store_logs: sets last_value and last_detail correctly", function()
+    reset_prefs()
+    logger.store_logs({
+        { "Intervention", "physio", "one" },
+        { "Intervention", "physio", "two" },
+        { "Intervention", "physio", "three" },
+    })
+
+    test.assert_equals(mock_prefs.logs["Intervention"].last_value, "physio", "last_value")
+    test.assert_equals(mock_prefs.logs["Intervention"].values["physio"].last_detail, "three", "last_detail should be last in batch")
+end)
+
+-- Run tests
+if ... == nil then
+    test.run_tests()
+    os.exit(test.failed == 0 and 0 or 1)
+end


### PR DESCRIPTION
When log_events_to_spreadsheet logs multiple events with the same
event+value (e.g. three intervention/physio items with different
details), the event and value counts now increment by 1 instead of n.

Adds store_logs() batch function that tracks seen event and event+value
keys to avoid redundant parent-level count increments, while still
incrementing each unique detail count individually.

https://claude.ai/code/session_01VCuyA1tzQAHn6FXZZ89uLZ